### PR TITLE
Hide child from process list

### DIFF
--- a/cmd/child.go
+++ b/cmd/child.go
@@ -36,7 +36,7 @@ func child(_ *cobra.Command, args []string) error {
 		// If no explicit command and no default command, use the default command from the image
 		defaultCommand, err := getDefaultCommand(image)
 		if err != nil {
-			return fmt.Errorf("error getting default command: %v", err)
+			return fmt.Errorf("error getting default command: %w", err)
 		}
 		cmdArgs = defaultCommand
 	}
@@ -50,39 +50,39 @@ func child(_ *cobra.Command, args []string) error {
 	defer cleanupTempDir(tempDir)
 
 	if err := os.MkdirAll(tempDir, 0o770); err != nil {
-		return fmt.Errorf("error creating temp directory: %v", err)
+		return fmt.Errorf("error creating temp directory: %w", err)
 	}
 
 	if err := exec.Command("tar", "xvf", "assets/"+image+".tar.gz", "-C", tempDir, "--no-same-owner").Run(); err != nil {
-		return fmt.Errorf("error extracting image: %v", err)
+		return fmt.Errorf("error extracting image: %w", err)
 	}
 
 	newRootFolder := fmt.Sprintf("/var/lib/container-runtime/%s", containerID)
 
 	// move the temp folder to the root filesystem /var/lib/container-runtime/<containerID>
 	if err := os.Rename(tempDir, newRootFolder); err != nil {
-		return fmt.Errorf("error moving temp directory: %v", err)
+		return fmt.Errorf("error moving temp directory: %w", err)
 	}
 
 	if err := syscall.Sethostname([]byte(containerID)); err != nil {
-		return fmt.Errorf("error setting hostname: %v", err)
+		return fmt.Errorf("error setting hostname: %w", err)
 	}
 
 	if err := syscall.Chroot(newRootFolder); err != nil {
-		return fmt.Errorf("error changing root filesystem: %v", err)
+		return fmt.Errorf("error changing root filesystem: %w", err)
 	}
 
 	if err := os.Chdir("/"); err != nil {
-		return fmt.Errorf("error changing directory: %v", err)
+		return fmt.Errorf("error changing directory: %w", err)
 	}
 
 	if err := syscall.Mount("proc", "proc", "proc", 0, ""); err != nil {
-		return fmt.Errorf("error mounting proc: %v", err)
+		return fmt.Errorf("error mounting proc: %w", err)
 	}
 
 	fmt.Printf("Running command: %v\n", cmdArgs)
 	if err := syscall.Exec(cmdArgs[0], cmdArgs, os.Environ()); err != nil {
-		return fmt.Errorf("error: %v", err)
+		return fmt.Errorf("command %s with args %s failed with error: %w", cmdArgs[0], cmdArgs, err)
 	}
 
 	return nil
@@ -94,10 +94,11 @@ func generateContainerID() string {
 }
 
 // cleanupTempDir removes the temporary directory
-func cleanupTempDir(tempDir string) {
+func cleanupTempDir(tempDir string) error {
 	if err := os.RemoveAll(tempDir); err != nil {
-		fmt.Printf("Error cleaning up temp directory %s: %v\n", tempDir, err)
+		return fmt.Errorf("Error cleaning up temp directory %s: %w\n", tempDir, err)
 	}
+	return nil
 }
 
 func init() {

--- a/cmd/child.go
+++ b/cmd/child.go
@@ -81,14 +81,10 @@ func child(_ *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Running command: %v\n", cmdArgs)
-	execCmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
-	execCmd.Stdin = os.Stdin
-	execCmd.Stdout = os.Stdout
-	execCmd.Stderr = os.Stderr
-
-	if err := execCmd.Run(); err != nil {
+	if err := syscall.Exec(cmdArgs[0], cmdArgs, os.Environ()); err != nil {
 		return fmt.Errorf("error: %v", err)
 	}
+
 	return nil
 }
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -24,7 +24,7 @@ func deleteContainer(_ *cobra.Command, args []string) error {
 		reader := bufio.NewReader(os.Stdin)
 		input, err := reader.ReadString('\n')
 		if err != nil {
-			return fmt.Errorf("error reading input: %v", err)
+			return fmt.Errorf("error reading input: %w", err)
 		}
 		if strings.ToLower(strings.TrimSpace(input)) != "y" {
 			return fmt.Errorf("operation cancelled")
@@ -34,7 +34,7 @@ func deleteContainer(_ *cobra.Command, args []string) error {
 
 		containerDir, err := os.ReadDir(rootPath)
 		if err != nil {
-			return fmt.Errorf("error reading root path: %v", err)
+			return fmt.Errorf("error reading root path: %w", err)
 		}
 		for _, container := range containerDir {
 			if container.IsDir() {
@@ -42,7 +42,7 @@ func deleteContainer(_ *cobra.Command, args []string) error {
 				containerPath := fmt.Sprintf("%s/%s", rootPath, containerID)
 
 				if err := os.RemoveAll(containerPath); err != nil {
-					return fmt.Errorf("error deleting container: %v", err)
+					return fmt.Errorf("error deleting container: %w", err)
 				}
 				fmt.Println("Deleted container: ", containerID)
 			}
@@ -57,7 +57,7 @@ func deleteContainer(_ *cobra.Command, args []string) error {
 		containerPath := fmt.Sprintf("%s/%s", rootPath, containerID)
 
 		if err := os.RemoveAll(containerPath); err != nil {
-			return fmt.Errorf("error deleting container: %v", err)
+			return fmt.Errorf("error deleting container: %w", err)
 		}
 	}
 	return nil

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -19,7 +19,7 @@ var rootPath = "/var/lib/container-runtime"
 func list(_ *cobra.Command, _ []string) error {
 	containerDir, err := os.ReadDir(rootPath)
 	if err != nil {
-		return fmt.Errorf("error reading root path: %v", err)
+		return fmt.Errorf("error reading root path: %w", err)
 	}
 
 	var validContainers []string

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -34,7 +34,7 @@ func run(_ *cobra.Command, args []string) error {
 
 	// Start the command and wait for it to finish
 	if err := execCmd.Run(); err != nil {
-		return fmt.Errorf("error starting child process: %v", err)
+		return fmt.Errorf("error starting child process: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
In order to hide the child process from the process list, we can use a syscall to execute the actual command.